### PR TITLE
fix: missing quote in domain verifyingContract q14

### DIFF
--- a/src/data/questions.ts
+++ b/src/data/questions.ts
@@ -891,7 +891,7 @@ Please sign this transaction if doing so will bring you closer to executing, oth
     },
     "domain": {
         "chainId": "0xa4b1",
-        "verifyingContract": "${MULTI_SIGNATURE_SIGNER_WALLET}
+        "verifyingContract": "${MULTI_SIGNATURE_SIGNER_WALLET}"
     },
     "primaryType": "SafeTx",
     "message": {


### PR DESCRIPTION
### Related issue

#23 

---
This pull request includes a minor fix to the `src/data/questions.ts` file. The change corrects a syntax issue by closing a string properly with a double quote.