### PR TITLE
Add google tag manger tag to root layout

### DIFF
--- a/src/app/GoogleAnalytics.tsx
+++ b/src/app/GoogleAnalytics.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import React from 'react';
+import Script from 'next/script';
+
+export default function GoogleAnalytics() {
+  return (
+    <>
+      <Script
+        src="https://www.googletagmanager.com/gtag/js?id=G-4EYV1MDWQC"
+        strategy="afterInteractive"
+      />
+      <Script id="google-analytics" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', 'G-4EYV1MDWQC');
+        `}
+      </Script>
+    </>
+  );
+} 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { NetworkProvider } from '@/components/NetworkProvider';
+import GoogleAnalytics from './GoogleAnalytics';
 
 export const metadata: Metadata = {
   title: "Wise Signer",
@@ -15,6 +16,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="bg-zinc-900 text-white">
+        <GoogleAnalytics />
         <NetworkProvider>{children}</NetworkProvider>
       </body>
     </html>


### PR DESCRIPTION
This PR adds the gtm code snippet into the root layout. It also has the `afterInteractive` strategy enabled to make sure it doesn't effect load speed.